### PR TITLE
Disable User title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Prefix your message with one of the following:
 - [Fixed] Updated SDPI CSS
 - [Changed] Improved handling of Settings update
 - [Added] Support for GitHub Enterprise
+- [Added] Disabled user title to avoid overrides
 
 ## v0.1.0 - 2023-04-08
 

--- a/src/actions/ViewReviewRequests.ts
+++ b/src/actions/ViewReviewRequests.ts
@@ -175,5 +175,6 @@ const action = new ViewReviewRequests({
 
 action.encoder = new Encoder();
 action.keyPad = false;
+action.enableUserTitle = false;
 
 export default action;


### PR DESCRIPTION
A title set by the user will override the text we put into the title and break the plugin. Using a new flag available now we are disabling it.

Closes #4.